### PR TITLE
Remove API word from navbar and fix headers to match sidebar

### DIFF
--- a/documentation/docs/getting-started/prerequisites.md
+++ b/documentation/docs/getting-started/prerequisites.md
@@ -1,0 +1,424 @@
+## Clone the repo
+
+```bash
+git clone https://github.com/ConsenSys/UniversalToken-extendable
+```
+
+```bash
+cd UniversalToken-extendable
+```
+
+## Add the libraries
+
+```bash
+yarn add truffle
+
+yarn add dotenv
+
+yarn add @truffle/hdwallet-provider
+```
+
+!!! note
+    I followed the steps to here. Everything after this is unchecked.
+
+!!!	warning
+	So, on adding hdwallet...yarn compiled every contract, which was completely unexpected. So, I'm going to stop here as there are too many unknowns and a load of errors.
+
+	
+	???	output
+		```bash
+		katharine@kmurphy+mbp documentation % yarn add @truffle/hdwallet-provider
+		yarn add v1.22.18
+		warning ../../../package.json: No license field
+		[1/4] 🔍  Resolving packages...
+		warning Resolution field "web3@1.7.3" is incompatible with requested version "web3@1.5.3"
+		warning Resolution field "web3@1.7.3" is incompatible with requested version "web3@1.5.3"
+		warning Resolution field "web3@1.7.3" is incompatible with requested version "web3@1.5.3"
+		warning Resolution field "web3@1.7.3" is incompatible with requested version "web3@1.5.3"
+		[2/4] 🚚  Fetching packages...
+		[3/4] 🔗  Linking dependencies...
+		warning "@openzeppelin/test-helpers > chai-bn@0.2.2" has unmet peer dependency "bn.js@^4.11.0".
+		warning " > @typechain/ethers-v5@8.0.5" has incorrect peer dependency "typechain@^6.0.4".
+		warning " > @typechain/ethers-v5@8.0.5" has unmet peer dependency "typescript@>=4.0.0".
+		warning " > @typechain/ethers-v5@8.0.5" has unmet peer dependency "ethers@^5.1.3".
+		warning " > @typechain/ethers-v5@8.0.5" has unmet peer dependency "@ethersproject/bytes@^5.0.0".
+		warning " > @typechain/ethers-v5@8.0.5" has unmet peer dependency "@ethersproject/providers@^5.0.0".
+		warning " > @typechain/ethers-v5@8.0.5" has unmet peer dependency "@ethersproject/abi@^5.0.0".
+		warning "@typechain/ethers-v5 > ts-essentials@7.0.3" has unmet peer dependency "typescript@>=3.7.0".
+		warning " > @typechain/truffle-v5@8.0.0" has unmet peer dependency "web3-core@^1".
+		warning " > @typechain/truffle-v5@8.0.0" has unmet peer dependency "web3-eth-contract@^1".
+		warning " > @typechain/truffle-v5@8.0.0" has unmet peer dependency "web3-utils@^1".
+		warning "truffle > @truffle/preserve-to-buckets > ipfs-http-client > native-abort-controller@0.0.3" has unmet peer dependency "abort-controller@*".
+		warning "truffle > @truffle/preserve-to-buckets > @textile/hub > @textile/buckets > @improbable-eng/grpc-web@0.13.0" has unmet peer dependency "google-protobuf@^3.2.0".
+		warning "truffle > @truffle/preserve-to-buckets > @textile/hub > @textile/hub-filecoin > @improbable-eng/grpc-web@0.12.0" has unmet peer dependency "google-protobuf@^3.2.0".
+		warning "truffle > @truffle/preserve-to-buckets > ipfs-http-client > multiaddr > dns-over-http-resolver > native-fetch@3.0.0" has unmet peer dependency "node-fetch@*".
+		warning " > typechain@8.0.0" has unmet peer dependency "typescript@>=4.3.0".
+		[4/4] 🔨  Building fresh packages...
+		[1/23] ⠐ keccak
+		[2/23] ⠐ secp256k1
+		[10/23] ⠐ sqlite3
+		[9/23] ⠐ leveldown
+		warning Error running install script for optional dependency: "/Users/katharine/Documents/doc-sites/UniversalToken-extendable/node_modules/sqlite3: Command failed.
+		Exit code: 1
+		Command: node-pre-gyp install --fallback-to-build
+		Arguments: 
+		Directory: /Users/katharine/Documents/doc-sites/UniversalToken-extendable/node_modules/sqlite3
+		Output:
+		node-pre-gyp info it worked if it ends with ok
+		node-pre-gyp info using node-pre-gyp@0.11.0
+		node-pre-gyp info using node@17.8.0 | darwin | arm64
+		node-pre-gyp WARN Using request for node-pre-gyp https download 
+		node-pre-gyp info check checked for \"/Users/katharine/Documents/doc-sites/UniversalToken-extendable/node_modules/sqlite3/lib/binding/node-v102-darwin-arm64/node_sqlite3.node\" (not found)
+		node-pre-gyp http GET https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v4.2.0/node-v102-darwin-arm64.tar.gz
+		node-pre-gyp http 403 https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v4.2.0/node-v102-darwin-arm64.tar.gz
+		node-pre-gyp WARN Tried to download(403): https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v4.2.0/node-v102-darwin-arm64.tar.gz 
+		node-pre-gyp WARN Pre-built binaries not found for sqlite3@4.2.0 and node@17.8.0 (node-v102 ABI, unknown) (falling back to source compile with node-gyp) 
+		node-pre-gyp http 403 status code downloading tarball https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v4.2.0/node-v102-darwin-arm64.tar.gz 
+		gyp info it worked if it ends with ok
+		gyp info using node-gyp@9.0.0
+		gyp info using node@17.8.0 | darwin | arm64
+		gyp info ok 
+		gyp info it worked if it ends with ok
+		gyp info using node-gyp@9.0.0
+		gyp info using node@17.8.0 | darwin | arm64
+		gyp info find Python using Python version 3.9.12 found at \"/opt/homebrew/opt/python@3.9/bin/python3.9\"
+		gyp info spawn /opt/homebrew/opt/python@3.9/bin/python3.9
+		gyp info spawn args [
+		gyp info spawn args   '/opt/homebrew/Cellar/node/17.8.0/libexec/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
+		gyp info spawn args   'binding.gyp',
+		gyp info spawn args   '-f',
+		gyp info spawn args   'make',
+		gyp info spawn args   '-I',
+		gyp info spawn args   '/Users/katharine/Documents/doc-sites/UniversalToken-extendable/node_modules/sqlite3/build/config.gypi',
+		gyp info spawn args   '-I',
+		gyp info spawn args   '/opt/homebrew/Cellar/node/17.8.0/libexec/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
+		gyp info spawn args   '-I',
+		gyp info spawn args   '/Users/katharine/Library/Caches/node-gyp/17.8.0/include/node/common.gypi',
+		gyp info spawn args   '-Dlibrary=shared_library',
+		gyp info spawn args   '-Dvisibility=default',
+		gyp info spawn args   '-Dnode_root_dir=/Users/katharine/Library/Caches/node-gyp/17.8.0',
+		gyp info spawn args   '-Dnode_gyp_dir=/opt/homebrew/Cellar/node/17.8.0/libexec/lib/node_modules/npm/node_modules/node-gyp',
+		gyp info spawn args   '-Dnode_lib_file=/Users/katharine/Library/Caches/node-gyp/17.8.0/<(target_arch)/node.lib',
+		gyp info spawn args   '-Dmodule_root_dir=/Users/katharine/Documents/doc-sites/UniversalToken-extendable/node_modules/sqlite3',
+		gyp info spawn args   '-Dnode_engine=v8',
+		gyp info spawn args   '--depth=.',
+		gyp info spawn args   '--no-parallel',
+		gyp info spawn args   '--generator-output',
+		gyp info spawn args   'build',
+		gyp info spawn args   '-Goutput_dir=.'
+		gyp info spawn args ]
+		gyp info ok 
+		gyp info it worked if it ends with ok
+		gyp info using node-gyp@9.0.0
+		gyp info using node@17.8.0 | darwin | arm64
+		gyp info spawn make
+		gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
+		  ACTION deps_sqlite3_gyp_action_before_build_target_unpack_sqlite_dep Release/obj/gen/sqlite-autoconf-3310100/sqlite3.c
+		/bin/sh: python: command not found
+		make: *** [Release/obj/gen/sqlite-autoconf-3310100/sqlite3.c] Error 127
+		gyp ERR! build error 
+		gyp ERR! stack Error: `make` failed with exit code: 2
+		gyp ERR! stack     at ChildProcess.onExit (/opt/homebrew/Cellar/node/17.8.0/libexec/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:194:23)
+		gyp ERR! stack     at ChildProcess.emit (node:events:527:28)
+		gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:291:12)
+		gyp ERR! System Darwin 21.5.0
+		gyp ERR! command \"/opt/homebrew/Cellar/node/17.8.0/bin/node\" \"/opt/homebrew/Cellar/node/17.8.0/libexec/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js\" \"build\" \"--fallback-to-build\" \"--module=/Users/katharine/Documents/doc-sites/UniversalToken-extendable/node_modules/sqlite3/lib/binding/node-v102-darwin-arm64/node_sqlite3.node\" \"--module_name=node_sqlite3\" \"--module_path=/Users/katharine/Documents/doc-sites/UniversalToken-extendable/node_modules/sqlite3/lib/binding/node-v102-darwin-arm64\" \"--napi_version=8\" \"--node_abi_napi=napi\" \"--napi_build_version=0\" \"--node_napi_label=node-v102\"
+		gyp ERR! cwd /Users/katharine/Documents/doc-sites/UniversalToken-extendable/node_modules/sqlite3
+		gyp ERR! node -v v17.8.0
+		gyp ERR! node-gyp -v v9.0.0
+		gyp ERR! not ok 
+		node-pre-gyp ERR! build error 
+		node-pre-gyp ERR! stack Error: Failed to execute 'node-gyp build --fallback-to-build --module=/Users/katharine/Documents/doc-sites/UniversalToken-extendable/node_modules/sqlite3/lib/binding/node-v102-darwin-arm64/node_sqlite3.node --module_name=node_sqlite3 --module_path=/Users/katharine/Documents/doc-sites/UniversalToken-extendable/node_modules/sqlite3/lib/binding/node-v102-darwin-arm64 --napi_version=8 --node_abi_napi=napi --napi_build_version=0 --node_napi_label=node-v102' (1)
+		node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/Users/katharine/Documents/doc-sites/UniversalToken-extendable/node_modules/node-pre-gyp/lib/util/compile.js:83:29)
+		node-pre-gyp ERR! stack     at ChildProcess.emit (node:events:527:28)
+		node-pre-gyp ERR! stack     at maybeClose (node:internal/child_process:1090:16)
+		node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:302:5)
+		node-pre-gyp ERR! System Darwin 21.5.0
+		node-pre-gyp ERR! command \"/opt/homebrew/Cellar/node/17.8.0/bin/node\" \"/Users/katharine/Documents/doc-sites/UniversalToken-extendable/node_modules/sqlite3/node_modules/.bin/node-pre-gyp\" \"install\" \"--fallback-to-build\"
+		node-pre-gyp ERR! cwd /Users/katharine/Documents/doc-sites/UniversalToken-extendable/node_modules/sqlite3
+		node-pre-gyp ERR! node -v v17.8.0
+		node-pre-gyp ERR! node-pre-gyp -v v0.11.0
+		node-pre-gyp ERR! not ok 
+		Failed to execute 'node-gyp build --fallback-to-build --module=/Users/katharine/Documents/doc-sites/UniversalToken-extendable/node_modules/sqlite3/lib/binding/node-v102-darwin-arm64/node_sqlite3.node success Saved lockfile.
+		warning Your current version of Yarn is out of date. The latest version is "1.22.19", while you're on "1.22.18".
+		info To upgrade, run the following command:
+		$ curl --compressed -o- -L https://yarnpkg.com/install.sh | bash
+		success Saved 1 new dependency.
+		info Direct dependencies
+		└─ @truffle/hdwallet-provider@2.0.9
+		info All dependencies
+		└─ @truffle/hdwallet-provider@2.0.9
+		$ yarn run build
+		yarn run v1.22.18
+		warning ../../../package.json: No license field
+		$ yarn run clean && truffle compile && yarn run generate-types
+		warning ../../../package.json: No license field
+		$ del-cli --force ./build && del-cli --force ./types
+
+		Compiling your contracts...
+		===========================
+		> Compiling ./contracts/ERC20.sol
+		> Compiling ./contracts/ERC721.sol
+		> Compiling ./contracts/IERC20Extendable.sol
+		> Compiling ./contracts/IERC721Extendable.sol
+		> Compiling ./contracts/Migrations.sol
+		> Compiling ./contracts/examples/allowblock/allow/AllowExtension.sol
+		> Compiling ./contracts/examples/allowblock/allow/IAllowlistedAdminRole.sol
+		> Compiling ./contracts/examples/allowblock/allow/IAllowlistedRole.sol
+		> Compiling ./contracts/examples/allowblock/block/BlockExtension.sol
+		> Compiling ./contracts/examples/allowblock/block/IBlocklistedAdminRole.sol
+		> Compiling ./contracts/examples/allowblock/block/IBlocklistedRole.sol
+		> Compiling ./contracts/examples/certificates/CertificateLib.sol
+		> Compiling ./contracts/examples/certificates/CertificateValidatorExtension.sol
+		> Compiling ./contracts/examples/certificates/ICertificateValidator.sol
+		> Compiling ./contracts/examples/holds/HoldExtension.sol
+		> Compiling ./contracts/examples/holds/HoldStatusCode.sol
+		> Compiling ./contracts/examples/holds/IHoldableToken.sol
+		> Compiling ./contracts/examples/pausable/IPausable.sol
+		> Compiling ./contracts/examples/pausable/PauseExtension.sol
+		> Compiling ./contracts/extensions/ExtensionBase.sol
+		> Compiling ./contracts/extensions/ExtensionProxy.sol
+		> Compiling ./contracts/extensions/IExtension.sol
+		> Compiling ./contracts/extensions/IExtensionMetadata.sol
+		> Compiling ./contracts/extensions/TokenExtension.sol
+		> Compiling ./contracts/tokens/IToken.sol
+		> Compiling ./contracts/tokens/TokenERC1820Provider.sol
+		> Compiling ./contracts/tokens/eventmanager/ITokenEventManager.sol
+		> Compiling ./contracts/tokens/eventmanager/TokenEventConstants.sol
+		> Compiling ./contracts/tokens/eventmanager/TokenEventManager.sol
+		> Compiling ./contracts/tokens/logic/ERC20/ERC20Logic.sol
+		> Compiling ./contracts/tokens/logic/ERC20/IERC20Logic.sol
+		> Compiling ./contracts/tokens/logic/ERC721/ERC721Logic.sol
+		> Compiling ./contracts/tokens/logic/ERC721/IERC721Logic.sol
+		> Compiling ./contracts/tokens/logic/ITokenLogic.sol
+		> Compiling ./contracts/tokens/logic/TokenLogic.sol
+		> Compiling ./contracts/tokens/proxy/ExtendableTokenProxy.sol
+		> Compiling ./contracts/tokens/proxy/IExtendableTokenProxy.sol
+		> Compiling ./contracts/tokens/proxy/ITokenProxy.sol
+		> Compiling ./contracts/tokens/proxy/TokenProxy.sol
+		> Compiling ./contracts/tokens/registry/ERC1155TokenInterface.sol
+		> Compiling ./contracts/tokens/registry/ERC20TokenInterface.sol
+		> Compiling ./contracts/tokens/registry/ERC721TokenInterface.sol
+		> Compiling ./contracts/tokens/storage/RegisteredExtensionStorage.sol
+		> Compiling ./contracts/tokens/storage/TokenEventManagerStorage.sol
+		> Compiling ./contracts/tokens/storage/TokenProxyStorage.sol
+		> Compiling ./contracts/utils/DomainAware.sol
+		> Compiling ./contracts/utils/Errors.sol
+		> Compiling ./contracts/utils/erc1820/ERC1820Client.sol
+		> Compiling ./contracts/utils/erc1820/ERC1820Implementer.sol
+		> Compiling ./contracts/utils/erc1820/ERC1820Registry.sol
+		> Compiling ./contracts/utils/erc1820/IERC1820Implementer.sol
+		> Compiling ./contracts/utils/mocks/Clock.sol
+		> Compiling ./contracts/utils/mocks/ERC20LogicMock.sol
+		> Compiling ./contracts/utils/mocks/ERC721LogicMock.sol
+		> Compiling ./contracts/utils/mocks/MockAllowExtension.sol
+		> Compiling ./contracts/utils/mocks/MockBlockExtension.sol
+		> Compiling ./contracts/utils/roles/ITokenRoles.sol
+		> Compiling ./contracts/utils/roles/Roles.sol
+		> Compiling ./contracts/utils/roles/RolesBase.sol
+		> Compiling ./contracts/utils/roles/TokenRoles.sol
+		> Compiling ./contracts/utils/roles/TokenRolesConstants.sol
+		> Compiling @openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol
+		> Compiling @openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol
+		> Compiling @openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol
+		> Compiling @openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol
+		> Compiling @openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol
+		> Compiling @openzeppelin/contracts-upgradeable/token/ERC721/IERC721ReceiverUpgradeable.sol
+		> Compiling @openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol
+		> Compiling @openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721BurnableUpgradeable.sol
+		> Compiling @openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol
+		> Compiling @openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721URIStorageUpgradeable.sol
+		> Compiling @openzeppelin/contracts-upgradeable/token/ERC721/extensions/IERC721EnumerableUpgradeable.sol
+		> Compiling @openzeppelin/contracts-upgradeable/token/ERC721/extensions/IERC721MetadataUpgradeable.sol
+		> Compiling @openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol
+		> Compiling @openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol
+		> Compiling @openzeppelin/contracts-upgradeable/utils/StringsUpgradeable.sol
+		> Compiling @openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol
+		> Compiling @openzeppelin/contracts-upgradeable/utils/introspection/IERC165Upgradeable.sol
+		> Compiling @openzeppelin/contracts/access/Ownable.sol
+		> Compiling @openzeppelin/contracts/token/ERC20/IERC20.sol
+		> Compiling @openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol
+		> Compiling @openzeppelin/contracts/token/ERC721/IERC721.sol
+		> Compiling @openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol
+		> Compiling @openzeppelin/contracts/utils/Context.sol
+		> Compiling @openzeppelin/contracts/utils/StorageSlot.sol
+		> Compiling @openzeppelin/contracts/utils/introspection/IERC165.sol
+		> Compiling @openzeppelin/contracts/utils/introspection/IERC1820Registry.sol
+		> Compiling @openzeppelin/contracts/utils/math/SafeMath.sol
+		> Compiling solidity-bytes-utils/contracts/BytesLib.sol
+		> Compilation warnings encountered:
+
+		    Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/ERC721.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/IERC721Extendable.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/tokens/logic/ERC721/ERC721Logic.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/tokens/logic/ERC721/IERC721Logic.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/tokens/registry/ERC1155TokenInterface.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/tokens/registry/ERC721TokenInterface.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/utils/DomainAware.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/utils/Errors.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/utils/erc1820/ERC1820Client.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/utils/erc1820/ERC1820Implementer.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/utils/erc1820/ERC1820Registry.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/utils/erc1820/IERC1820Implementer.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/utils/mocks/Clock.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/utils/mocks/ERC20LogicMock.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/utils/mocks/ERC721LogicMock.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/utils/mocks/MockAllowExtension.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/utils/mocks/MockBlockExtension.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/utils/roles/ITokenRoles.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/utils/roles/Roles.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/utils/roles/RolesBase.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/utils/roles/TokenRoles.sol
+
+		,Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+		--> project:/contracts/utils/roles/TokenRolesConstants.sol
+
+		,Warning: Source file does not specify required compiler version! Consider adding "pragma solidity ^0.8.7;"
+		--> project:/contracts/utils/Errors.sol
+
+		,Warning: This declaration shadows an existing declaration.
+		   --> project:/contracts/examples/pausable/PauseExtension.sol:121:9:
+		    |
+		121 |         bool isPaused = isPausedFor(data.from);
+		    |         ^^^^^^^^^^^^^
+		Note: The shadowed declaration is here:
+		  --> project:/contracts/examples/pausable/PauseExtension.sol:58:5:
+		   |
+		58 |     function isPaused() public view override returns (bool) {
+		   |     ^ (Relevant source part starts here and spans across multiple lines).
+
+		,Warning: "this" used in constructor. Note that external functions of a contract cannot be called while it is being constructed.
+		  --> project:/contracts/examples/holds/HoldExtension.sol:28:27:
+		   |
+		28 |         _registerFunction(this.hold.selector);
+		   |                           ^^^^
+
+		,Warning: "this" used in constructor. Note that external functions of a contract cannot be called while it is being constructed.
+		  --> project:/contracts/examples/holds/HoldExtension.sol:29:27:
+		   |
+		29 |         _registerFunction(this.releaseHold.selector);
+		   |                           ^^^^
+
+		,Warning: "this" used in constructor. Note that external functions of a contract cannot be called while it is being constructed.
+		  --> project:/contracts/examples/holds/HoldExtension.sol:30:27:
+		   |
+		30 |         _registerFunction(this.balanceOnHold.selector);
+		   |                           ^^^^
+
+		,Warning: "this" used in constructor. Note that external functions of a contract cannot be called while it is being constructed.
+		  --> project:/contracts/examples/holds/HoldExtension.sol:31:27:
+		   |
+		31 |         _registerFunction(this.spendableBalanceOf.selector);
+		   |                           ^^^^
+
+		,Warning: "this" used in constructor. Note that external functions of a contract cannot be called while it is being constructed.
+		  --> project:/contracts/examples/holds/HoldExtension.sol:32:27:
+		   |
+		32 |         _registerFunction(this.holdStatus.selector);
+		   |                           ^^^^
+
+		,Warning: "this" used in constructor. Note that external functions of a contract cannot be called while it is being constructed.
+		 --> project:/contracts/utils/mocks/MockAllowExtension.sol:7:27:
+		  |
+		7 |         _registerFunction(this.mockUpgradeTest.selector);
+		  |                           ^^^^
+
+		,Warning: "this" used in constructor. Note that external functions of a contract cannot be called while it is being constructed.
+		 --> project:/contracts/utils/mocks/MockBlockExtension.sol:7:27:
+		  |
+		7 |         _registerFunction(this.mockUpgradeTest.selector);
+		  |                           ^^^^
+
+		,Warning: Function state mutability can be restricted to view
+		   --> project:/contracts/examples/allowblock/allow/AllowExtension.sol:118:5:
+		    |
+		118 |     function onTransferExecuted(TransferData memory data)
+		    |     ^ (Relevant source part starts here and spans across multiple lines).
+
+		,Warning: Function state mutability can be restricted to view
+		   --> project:/contracts/examples/allowblock/block/BlockExtension.sol:110:5:
+		    |
+		110 |     function onTransferExecuted(TransferData memory data)
+		    |     ^ (Relevant source part starts here and spans across multiple lines).
+
+		,Warning: Function state mutability can be restricted to view
+		   --> project:/contracts/examples/pausable/PauseExtension.sol:116:5:
+		    |
+		116 |     function onTransferExecuted(TransferData memory data)
+		    |     ^ (Relevant source part starts here and spans across multiple lines).
+
+
+		> Artifacts written to /Users/katharine/Documents/doc-sites/UniversalToken-extendable/build/contracts
+		> Compiled successfully using:
+		   - solc: 0.8.7+commit.e28d00a7.Emscripten.clang
+		warning ../../../package.json: No license field
+		$ typechain --target=truffle-v5 'build/contracts/*.json'
+		Could not parse type: function with internal type: function (struct TransferData) external returns (bool).
+
+		Please submit a GitHub Issue to the TypeChain team with the failing contract/library.
+		Could not parse type: function with internal type: function (struct TransferData) external returns (bool).
+
+		Please submit a GitHub Issue to the TypeChain team with the failing contract/library.
+		Could not parse type: function with internal type: function (struct TransferData) external returns (bool).
+
+		Please submit a GitHub Issue to the TypeChain team with the failing contract/library.
+		Could not parse type: function with internal type: function (struct TransferData) external returns (bool).
+
+		Please submit a GitHub Issue to the TypeChain team with the failing contract/library.
+		Could not parse type: function with internal type: function (struct TransferData) external returns (bool).
+
+		Please submit a GitHub Issue to the TypeChain team with the failing contract/library.
+		Could not parse type: function with internal type: function (struct TransferData) external returns (bool).
+
+		Please submit a GitHub Issue to the TypeChain team with the failing contract/library.
+		Could not parse type: function with internal type: function (struct TransferData) external returns (bool).
+
+		Please submit a GitHub Issue to the TypeChain team with the failing contract/library.
+		Successfully generated 78 typings!
+		✨  Done in 22.36s.
+		$ husky install
+		husky - Git hooks installed
+		✨  Done in 65.37s.
+
+		```

--- a/documentation/docs/tokens/extendable-token-proxy.md
+++ b/documentation/docs/tokens/extendable-token-proxy.md
@@ -1,4 +1,4 @@
-## Extendable Token Proxy
+# Extendable Token Proxy
 
 The `ExtendableTokenProxy` is the smart contract responsible for managing both the [EIP1967 Proxy](https://eips.ethereum.org/EIPS/eip-1967) logic as well as the extension registration/execution logic. This contract also has functions to manage roles through the `TokenRoles` contract. 
 

--- a/documentation/docs/tokens/overview.md
+++ b/documentation/docs/tokens/overview.md
@@ -1,10 +1,23 @@
-## TokenProxy API
+# Overview
+
+The token smart contracts consist of two primary contracts. The `TokenProxy` and the `TokenLogic`. The token proxy is responsible for
+
+1. Managing token roles
+2. Managing the current token logic implementation contract
+
+The primary smart contract used by all implementations in the repo is the [ExtendableTokenProxy](./extendable-token-proxy.md) which adds supports
+for extensions and is responsible for
+
+1. Managing token extensions
+2. Routing calls to either the token logic contract or extensions (based on function selector)
+
+# TokenProxy Functionality
 
 This section discusses the different functions of the `TokenProxy` that is used by every token standard contract deployed (`ERC20`, `ERC721`, etc.).
 
 This section assumes you have a token deployed on-chain and you have access to the token contract via a Truffle contract variable named `token` inside a script. However, these functions can be used by any client such as with Etherscan or with Hardhat. 
 
-# Token Interface
+## Interface
 
 The `IToken` interface is the interface that all token contracts must adhere to. 
 

--- a/documentation/docs/tokens/token-logic.md
+++ b/documentation/docs/tokens/token-logic.md
@@ -1,4 +1,4 @@
-## Token Logic
+# Token Logic
 
 The `TokenLogic` is the smart contract responsible for
 
@@ -14,7 +14,7 @@ This is the contract you must inherit from to build custom token implementations
 
 To extend the token logic to add functionality, you can simply inherit from `ERC20Logic` or `ERC721Logic`. These two contracts work great on their own, but can also be extended to add additional functionality or change the behavior.
 
-When adding additional functions, be sure to update the [token proxy](./token-proxy.md) to protect any new functions.
+When adding additional functions, be sure to update the [token proxy](./extendable-token-proxy.md) to protect any new functions.
 
 ## Example of extending token logic
 

--- a/documentation/docs/tokens/token-roles.md
+++ b/documentation/docs/tokens/token-roles.md
@@ -1,5 +1,3 @@
-## Token roles
-
 Each token deployment has an access control mechanism that allows the creation of roles. Addresses can be assigned and de-assigned to roles. Roles can be used to limit access to specific functions. All token deployments come with four default roles, they are:
 
 1. [Minter](#minter)

--- a/documentation/docs/tokens/upgrading.md
+++ b/documentation/docs/tokens/upgrading.md
@@ -1,6 +1,6 @@
 # Upgrading Token Logic
 
-To upgrade/change the underlying [token logic](./token-logic.md) contract a [token proxy](./token-proxy.md) is using, simply run the `upgradeTo(address logic, bytes memory data)` function in the token proxy.
+To upgrade/change the underlying [token logic](./token-logic.md) contract a [token proxy](./overview.md) is using, simply run the `upgradeTo(address logic, bytes memory data)` function in the token proxy.
 
 The `address` provided will be the new logic contract that will be used, and the `data` provided will be passed to the logic contract's `_onInitialize` function
 

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -24,18 +24,18 @@ nav:
   - Overview: 
       - Welcome: overview/welcome.md
       - Releases: overview/releases.md
-  - Token API: 
+  - Token: 
       - Overview: tokens/overview.md
-      - Token Proxy: tokens/token-proxy.md
+      - Extendable Token Proxy: tokens/extendable-token-proxy.md
       - Token Logic: tokens/token-logic.md
       - Token Roles: tokens/token-roles.md
       - Upgrading Token Logic: tokens/upgrading.md
   - Extensions: 
-      - Getting started: extensions/getting-started.md
+      - Overview: extensions/getting-started.md
       - Building extensions: extensions/building-extensions.md
       - Token events: extensions/token-events.md
       - Controlled transfers: extensions/controlled-transfers.md
-      - API: extensions/api.md
+      - TokenExtension API: extensions/api.md
   - Solidity API:
       - ERC20:  API/ERC20.md
       - ERC721:  API/ERC721.md


### PR DESCRIPTION
## Description

Fixes headers in documentation to match sidebar, removed "API" word from navbar. Added some overview text in Token Overview page

## Motivation and Context

navbar and sidebar were confusing since the page headers sometimes would not match

## Types of changes

- [x] Documentation Update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
